### PR TITLE
Add property to enable/disable launching the tether plugin

### DIFF
--- a/mars.orogen
+++ b/mars.orogen
@@ -583,6 +583,9 @@ task_context "Tether", subclasses: "Plugin" do
 
     property("tether_settings", "mars/plugins/tether_simulation/Params")
 
+    property("launch_tether_plugin", "bool", true)
+      doc("enable/disable launching the tether plugin")
+
     periodic 0.1
 
 end

--- a/tasks/Tether.cpp
+++ b/tasks/Tether.cpp
@@ -72,13 +72,18 @@ bool Tether::configureHook()
 {
     if (! TetherBase::configureHook())
         return false;
+
+    launch_tether_plugin = _launch_tether_plugin.get();
+
     return true;
 }
 bool Tether::startHook()
 {
     if (! TetherBase::startHook())
         return false;
-    
+
+    if(launch_tether_plugin)
+    {
     LOG_DEBUG("Beginning of the startHook: About to get the tether plugin from Mars");
     mars::interfaces::MarsPluginTemplate *TetherPluginInterface;
     if (Task::getPlugin("tether_simulation", TetherPluginInterface))
@@ -91,6 +96,7 @@ bool Tether::startHook()
     {
         LOG_DEBUG("Failed to obtain the Tether management plugin\n");
     }
+    }
 
     return true;
 }
@@ -99,6 +105,8 @@ void Tether::updateHook()
     TetherBase::updateHook();
     printf("%s:%i\n", __PRETTY_FUNCTION__, __LINE__);
 
+    if(launch_tether_plugin)
+    {
     base::samples::Joints cmd;
 
     while (_winch_command.read(cmd) == RTT::NewData ) {
@@ -114,8 +122,9 @@ void Tether::updateHook()
 
     _rope_length.write(tether_plugin->getFixedLength());
     _winch_force.write(tether_plugin->getForces());
-
+    }
 }
+
 void Tether::errorHook()
 {
     TetherBase::errorHook();
@@ -131,6 +140,9 @@ void Tether::cleanupHook()
 
 void  Tether::update( double time )
 {
+    if(launch_tether_plugin)
+    {
+
     if(!isRunning()) return; //Seems Plugin is set up but not active yet, we are not sure that we are initialized correctly so retuning
 
     if(!pluginInitialized)
@@ -138,5 +150,6 @@ void  Tether::update( double time )
         tether_plugin->updateSettings(_tether_settings.value());
         tether_plugin->init();
         pluginInitialized = true;
+    }
     }
 }

--- a/tasks/Tether.hpp
+++ b/tasks/Tether.hpp
@@ -34,6 +34,9 @@ namespace mars{
     // thread save target speed for handover from task thread to the sim update thread
     std::atomic<float> targetSpeed;
 
+    // Enable/disable launching the tether plugin in the simulator
+    bool launch_tether_plugin = true;
+
     public:
         /** TaskContext constructor for Tether
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.


### PR DESCRIPTION
Currently, the tether plugin is launched even if the config is in "inactive", then it fails since it does not find the nodes requested for the tether connections. This was not failing before, but now with this [exception](https://git.hb.dfki.de/mars/mars_plugin_collection/-/merge_requests/19) that we included, the simulator just crashes (when the tether plugin should not be even launched).

With this new property, if the config is "inactive", the tether component does not even try to reach the plugin and everything works as expected. 

@Rauldg 